### PR TITLE
Add bottom padding to main container to clear footer

### DIFF
--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -214,7 +214,7 @@ header nav a:hover {
 
 main {
   background-color: var(--background);
-  padding: 1rem 0;
+  padding: 1rem 0 3rem;
   box-shadow: 0px 0px 10px black, 0px 0px 20px black, 0px 0px 30px black;
   flex-grow: 1;
 }


### PR DESCRIPTION
Adresses #64. I noticed the footer's "purple wave" goes over the main container's content by default, so I added padding so that they can never overlap, no matter the main content. This also increases the space between the content and the footer on other pages but I checked a lot of them and I would say it looks good if not better than before.