### PR TITLE
Improve latest issue display

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -37,29 +37,27 @@ description: "o kama pona lon lipu pi lipu tenpo!"
     </a>
   </article>
 
-  <div class="lukin-insa">
-    {{#with (getkey collections lipu_ale.[0].title)}}
-    {{#if this}}
-    <ul>
-      {{#each this}}
-      <li>
-        <a class="article" href="{{page.url}}">
-          <span class="nimi-suli">{{data.[nimi-suli]}}</span>
-        </a>
-        <span class="jan-pali" style="color: {{colourhash data.[jan-pali]}}">
-          <span class="sitelen-pona">jan</span>
-          {{data.[jan-pali]}}
-        </span>
-        <span class="category" style="color: {{colourhash (getTokiTypeTag data.tags)}}">
-          <span class="sitelen-pona">{{getTokiTypeTag data.tags}}</span>
-          {{getTokiTypeTag data.tags}}
-        </span>
-      </li>
-      {{/each}}
-    </ul>
-    {{/if}}
-    {{/with}}
-  </div>
+  {{#with (getkey collections lipu_ale.[0].title)}}
+  {{#if this}}
+  <ul>
+    {{#each this}}
+    <li>
+      <a class="article" href="{{page.url}}">
+        <span class="nimi-suli">{{data.[nimi-suli]}}</span>
+      </a>
+      <span class="jan-pali" style="color: {{colourhash data.[jan-pali]}}">
+        <span class="sitelen-pona">jan</span>
+        {{data.[jan-pali]}}
+      </span>
+      <span class="category" style="color: {{colourhash (getTokiTypeTag data.tags)}}">
+        <span class="sitelen-pona">{{getTokiTypeTag data.tags}}</span>
+        {{getTokiTypeTag data.tags}}
+      </span>
+    </li>
+    {{/each}}
+  </ul>
+  {{/if}}
+  {{/with}}
 </section>
 
 

--- a/index.hbs
+++ b/index.hbs
@@ -23,16 +23,43 @@ description: "o kama pona lon lipu pi lipu tenpo!"
 {{!-- first lipu_ale --}}
 <section id="lipu-nanpa-lon">
   <article class="lipuwan">
+    <div class="lipu-sin">lipu sin</div>
+    <h3 id="{{ lipu_ale.[0].title }}">
+      <a href="lipu/{{slugify lipu_ale.[0].title}}">
+        {{ lipu_ale.[0].title }}
+      </a>
+    </h3>
+    <div class="date">
+      <time datetime="{{ asReadableDate lipu_ale.[0].date }}">{{ asReadableDate lipu_ale.[0].date }}</time>
+    </div>
     <a href="lipu/{{slugify lipu_ale.[0].title}}">
       {{{eleventyImage (appendString "pdfs/" lipu_ale.[0].cover_image) "" lipu_ale.[0].title 400}}}
-      <h3 id="{{ lipu_ale.[0].title }}">
-        {{ lipu_ale.[0].title }}
-      </h3>
-      <span class="date">
-        <time datetime="{{ asReadableDate lipu_ale.[0].date }}">{{ asReadableDate lipu_ale.[0].date }}</time>
-      </span>
     </a>
   </article>
+
+  <div class="lukin-insa">
+    {{#with (getkey collections lipu_ale.[0].title)}}
+    {{#if this}}
+    <ul>
+      {{#each this}}
+      <li>
+        <a class="article" href="{{page.url}}">
+          <span class="nimi-suli">{{data.[nimi-suli]}}</span>
+        </a>
+        <span class="jan-pali" style="color: {{colourhash data.[jan-pali]}}">
+          <span class="sitelen-pona">jan</span>
+          {{data.[jan-pali]}}
+        </span>
+        <span class="category" style="color: {{colourhash (getTokiTypeTag data.tags)}}">
+          <span class="sitelen-pona">{{getTokiTypeTag data.tags}}</span>
+          {{getTokiTypeTag data.tags}}
+        </span>
+      </li>
+      {{/each}}
+    </ul>
+    {{/if}}
+    {{/with}}
+  </div>
 </section>
 
 

--- a/public/stylesheet-index.css
+++ b/public/stylesheet-index.css
@@ -100,9 +100,10 @@
 
 #lipu-nanpa-lon {
   display: flex;
+  flex-flow: row wrap;
   justify-content: center;
-  align-items: center;
-  margin: 2rem 0;
+  align-items: flex-end;
+  margin: 2rem;
 }
 
 .lipu-flex {
@@ -162,4 +163,32 @@
 }
 .lipuwan a:hover {
   text-decoration: underline;
+}
+
+#lipu-nanpa-lon .lipuwan {
+  margin-right: 2rem;
+  max-width: none;
+  display: block;
+  text-align: left;
+}
+#lipu-nanpa-lon .lipu-sin {
+  font-size: 2rem;
+  font-weight: bold;
+  line-height: 1;
+  text-transform: uppercase;
+}
+#lipu-nanpa-lon .lipuwan h3 {
+  margin: 0;
+  font-size: 3rem;
+  font-weight: bold;
+  line-height: 1;
+  text-transform: uppercase;
+}
+#lipu-nanpa-lon .lipuwan .date {
+  font-size: 2rem;
+  line-height: 1;
+}
+#lipu-nanpa-lon .lipuwan img {
+  margin-top: .7rem;
+  max-width: 15rem;
 }

--- a/public/stylesheet-index.css
+++ b/public/stylesheet-index.css
@@ -187,7 +187,7 @@
 }
 #lipu-nanpa-lon .lipuwan img {
   margin-top: .7rem;
-  max-width: 15rem;
+  max-width: 12rem;
 }
 #lipu-nanpa-lon .jan-pali {
   padding: 0 .5rem;

--- a/public/stylesheet-index.css
+++ b/public/stylesheet-index.css
@@ -175,18 +175,15 @@
   font-size: 2rem;
   font-weight: bold;
   line-height: 1;
-  text-transform: uppercase;
 }
 #lipu-nanpa-lon .lipuwan h3 {
   margin: 0;
   font-size: 3rem;
   font-weight: bold;
   line-height: 1;
-  text-transform: uppercase;
 }
 #lipu-nanpa-lon .lipuwan .date {
-  font-size: 2rem;
-  line-height: 1;
+  font-size: 1.7rem;
 }
 #lipu-nanpa-lon .lipuwan img {
   margin-top: .7rem;

--- a/public/stylesheet-index.css
+++ b/public/stylesheet-index.css
@@ -189,3 +189,6 @@
   margin-top: .7rem;
   max-width: 15rem;
 }
+#lipu-nanpa-lon .jan-pali {
+  padding: 0 .5rem;
+}

--- a/public/stylesheet-lipu.css
+++ b/public/stylesheet-lipu.css
@@ -115,9 +115,6 @@ h2 {
   color: var(--colour-laso-pimeja);
   border-radius: var(--blob-border-radius-04);
 }
-.sitelen-pona {
-  font-family: "sitelen seli kiwen", sans-serif;
-}
 .toki ul {
   margin: 0;
   padding: 0;

--- a/public/stylesheet.css
+++ b/public/stylesheet.css
@@ -364,3 +364,7 @@ footer .licence {
     }
   }
 }
+
+.sitelen-pona {
+  font-family: "sitelen seli kiwen", sans-serif;
+}


### PR DESCRIPTION
I thought it might be nice to highlight the latest issue on the homepage and link directly to the content. I took a shot but I'm open to feedback.

## Current

<img width="1092" alt="Screenshot 2024-07-03 at 5 32 58 PM" src="https://github.com/lipu-tenpo/liputenpo.org/assets/1723212/75e1beb6-0448-4aa4-904f-3d726c691148">

## My Proposal

<img width="1092" alt="Screenshot 2024-07-03 at 5 29 19 PM" src="https://github.com/lipu-tenpo/liputenpo.org/assets/1723212/6be8afaf-418d-4ace-82b0-d643331c122c">
