### PR TITLE
Add name of article to page title

### DIFF
--- a/_includes/toki.hbs
+++ b/_includes/toki.hbs
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: "lipu tenpo - toki"
 css:
   - stylesheet-toki-wan.css
 eleventyComputed:
+  title: "{{[nimi-suli]}} - lipu tenpo"
   description: "{{[nimi-suli]}}"
 ---
 <article class="toki">


### PR DESCRIPTION
Closes #81. I used the format "<title> - lipu tenpo" because I believe that's what's best for users and for search engines, and it's what I see other mainstream online publications do.