### PR TITLE
Add pdfs.hbs [WIP]

### DIFF
--- a/_data/sona.yaml
+++ b/_data/sona.yaml
@@ -1,4 +1,5 @@
 site: https://liputenpo.org
+linluwi-pi-pdf-ale: https://github.com/lipu-tenpo/liputenpo.org/tree/main/pdfs
 ni-li-seme:
   - question: "What is this?"
     answer: "Hello! You’re looking at the website for lipu tenpo, a magazine written in Toki Pona. Maybe you’re new and want to know more about this language. Great! This page hopes to answer some of your questions."

--- a/pdfs.hbs
+++ b/pdfs.hbs
@@ -14,7 +14,7 @@ css:
 <section id="introduction">
   <p>o kama pona!</p>
   <p>o lukin e lipu ale lon ni.</p>
-  <p>o kama jo e lipu ale <a href="https://github.com/lipu-tenpo/liputenpo.org/tree/main/pdfs">lon ni</a>.</p>
+  <p>o kama jo e lipu ale <a href="{{sona.linluwi-pi-pdf-ale}}">lon ni</a>.</p>
 </section>
 
 <div class="lipu-flex">

--- a/pdfs.hbs
+++ b/pdfs.hbs
@@ -14,6 +14,7 @@ css:
 <section id="introduction">
   <p>o kama pona!</p>
   <p>o lukin e lipu ale lon ni.</p>
+  <p>o kama jo e lipu ale <a href="https://github.com/lipu-tenpo/liputenpo.org/tree/main/pdfs">lon ni</a>.</p>
 </section>
 
 <div class="lipu-flex">

--- a/pdfs.hbs
+++ b/pdfs.hbs
@@ -1,0 +1,49 @@
+---
+layout: page
+title: "lipu tenpo - pdfs"
+css:
+  - stylesheet-index.css
+---
+
+<div class="h2">
+  <h2 id="pdf">
+    lipu pdf
+  </h2>
+</div>
+
+
+<section id="introduction">
+  <p>o kama pona!</p>
+  <p>o lukin e lipu pdf ale lon ni.</p>
+</section>
+
+<div class="lipu-flex">
+  <section id="lipu_ale">
+    {{#each lipu_ale}}
+    <div>
+      <article class="lipuwan">
+          {{{eleventyImage (appendString "pdfs/" cover_image) "" title 400}}}
+          <h3 id="{{ this.title }}">
+            {{ this.title }}
+          </h3>
+          <span class="date">
+            <time datetime="{{ asReadableDate this.date }}">{{ asReadableDate this.date }}</time>
+          </span>
+          <div class="pdf-links">
+            <a href="{{this.pdf}}">
+              <span>Color A5 PDF</span>
+            </a>
+            <br>
+            <a href="{{this.pdf_pf}}">
+              <span>Color A4 PDF</span>
+            </a>
+            <br>
+            <a href="{{this.pdf_bwpf}}">
+              <span>B&W A4 PDF</span>
+            </a>
+          </div>
+      </article>
+    </div>
+    {{/each}}
+  </section>
+</div>

--- a/pdfs.hbs
+++ b/pdfs.hbs
@@ -17,10 +17,10 @@ css:
 </section>
 
 <div class="lipu-flex">
-  <section id="lipu_ale">
+  <section id="lipu_ale_pdf">
     {{#each lipu_ale}}
     <div>
-      <article class="lipuwan">
+      <article class="lipuwan lipuwan_pdf">
           {{{eleventyImage (appendString "pdfs/" cover_image) "" title 400}}}
           <h3 id="{{ this.title }}">
             {{ this.title }}

--- a/pdfs.hbs
+++ b/pdfs.hbs
@@ -7,14 +7,13 @@ css:
 
 <div class="h2">
   <h2 id="pdf">
-    lipu pdf
+    lipu
   </h2>
 </div>
 
-
 <section id="introduction">
   <p>o kama pona!</p>
-  <p>o lukin e lipu pdf ale lon ni.</p>
+  <p>o lukin e lipu ale lon ni.</p>
 </section>
 
 <div class="lipu-flex">
@@ -30,17 +29,29 @@ css:
             <time datetime="{{ asReadableDate this.date }}">{{ asReadableDate this.date }}</time>
           </span>
           <div class="pdf-links">
+            {{#if this.pdf}}
             <a href="{{this.pdf}}">
-              <span>Color A5 PDF</span>
+              <span>lipu kule</span>
             </a>
             <br>
+            {{/if}}
+            {{#if this.pdf_pf}}
             <a href="{{this.pdf_pf}}">
-              <span>Color A4 PDF</span>
+              <span>lipu tawa ilo sitelen</span>
             </a>
             <br>
+            {{/if}}
+            {{#if this.pdf_bwpf}}
             <a href="{{this.pdf_bwpf}}">
-              <span>B&W A4 PDF</span>
+              <span>lipu walo tawa ilo sitelen</span>
             </a>
+            <br>
+            {{/if}}
+            {{#if this.pdf_sitelen_pona}}
+            <a href="{{this.pdf_sitelen_pona}}">
+              <span>lipu pi sitelen pona</span>
+            </a>
+            {{/if}}
           </div>
       </article>
     </div>

--- a/public/stylesheet-index.css
+++ b/public/stylesheet-index.css
@@ -192,3 +192,23 @@
 #lipu-nanpa-lon .jan-pali {
   padding: 0 .5rem;
 }
+
+#lipu_ale_pdf {
+  padding: 3rem 2rem 2rem;
+  width: 100%;
+  max-width: 60rem;
+
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  grid-gap: 4rem;
+}
+
+.lipuwan_pdf {
+  max-width: 13em;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+}


### PR DESCRIPTION
This is a first shot at issue #117.

A few notes:
- I didn't include the bleed pdf because I didn't see a use case for the normal user. The only time one would need a bleed pdf would be for professional printing, correct? Including the bleed pdf is trivial, so if I'm mistaken in understanding the use case, I'm happy to add it.
- I used the existing styles from `stylesheet-index.css` and avoided adding more code to the css file. This means that added a few manual breaks into the hbs template. I believe this is simpler and more maintainable than editing the css to account for the flexbox spacing.
- I used good judgment on the copy, but I'm not attached to it if we want to change it.


Any and all feedback is welcome!